### PR TITLE
Add 'get_username' route

### DIFF
--- a/src/auth_server.py
+++ b/src/auth_server.py
@@ -502,6 +502,10 @@ async def lif_password_update(username: str = Form(), current_password: str = Fo
         return JSONResponse(status_code=200, content='Updated Password')
     else: 
         raise HTTPException(status_code=401, detail="Invalid Password!")
+    
+@app.get('/get_username/{account_id}')
+async def get_username(account_id: str):
+    return database.get_username(account_id=account_id)
 
 if __name__ == '__main__':
     import uvicorn

--- a/src/utils/db_interface.py
+++ b/src/utils/db_interface.py
@@ -248,3 +248,12 @@ def get_user_email(username: str):
     data = cursor.fetchone()
 
     return data[3]
+
+def get_username(account_id: str):
+    connect_to_database()
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM accounts WHERE user_id = %s", (account_id,))
+    data = cursor.fetchone()
+
+    return data[1]


### PR DESCRIPTION
### Description
Added a route to Auth Server called `/get_username/{account_id}` that allows services to get the username of an account simply by requesting it from Auth Server.