### PR TITLE
Fix account panel bio bug

### DIFF
--- a/src/auth_server.py
+++ b/src/auth_server.py
@@ -683,9 +683,14 @@ async def get_profile(username: str, service_url: str = "NA"):
     html_document = html_document.replace("{{USERNAME}}", username)
     html_document = html_document.replace("{{SERVICE_URL}}", service_url)
 
-    # Get user bio and add it to html
+    # Get user bio from database
     bio = database.info.get_bio(username)
-    html_document = html_document.replace("{{USER_BIO}}", bio)
+
+    # Check if a bio is set
+    if bio:
+        html_document = html_document.replace("{{USER_BIO}}", bio)
+    else:
+        html_document = html_document.replace("{{USER_BIO}}", "")
 
     # Return HTML document
     return html_document


### PR DESCRIPTION
## Description
Fixed a bug with the account panel bio where if a user didn't have a bio set, the server would return an error. 

## Related Issue
#88 

## Type of Change
<!-- Choose one or more types that describe the changes in this PR -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please specify)

## Checklist
<!-- Check all that apply -->
- [x] I have tested the changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated relevant comments or documentation
- [x] All tests pass successfully
- [x] This PR follows the project's coding standards
