### PR TITLE
Add caching limit for avatar and banner

### DIFF
--- a/src/auth_server.py
+++ b/src/auth_server.py
@@ -486,10 +486,15 @@ async def get_pfp(username: str):
 
     # Check if the file exists and is a regular file
     if os.path.isfile(avatar_path):
-        return FileResponse(avatar_path, media_type='image/gif')
+        response = FileResponse(avatar_path, media_type='image/gif')
     else:
         # Return default image if the user's banner doesn't exist
-        return FileResponse(f'{assets_folder}/default_pfp.png', media_type='image/gif')
+        response = FileResponse(f'{assets_folder}/default_pfp.png', media_type='image/gif')
+
+    # Add caching limit to image
+    response.headers["Cache-Control"] = "public, max-age=3600"
+
+    return response
 
 @app.get("/get_banner/{username}")
 @app.get("/profile/get_banner/{username}")
@@ -512,10 +517,15 @@ async def get_banner(username: str):
 
     # Check if the file exists and is a regular file
     if os.path.isfile(banner_path):
-        return FileResponse(banner_path, media_type='image/gif')
+        response = FileResponse(banner_path, media_type='image/gif')
     else:
         # Return default image if the user's banner doesn't exist
-        return FileResponse(f'{assets_folder}/default_banner.png', media_type='image/gif')
+        response = FileResponse(f'{assets_folder}/default_banner.png', media_type='image/gif')
+
+    # Add caching time limit to image
+    response.headers["Cache-Control"] = "public, max-age=3600"
+
+    return response
     
 @app.post("/create_lif_account")
 @app.post("/account/create_account")


### PR DESCRIPTION
## Description
Added caching limit for avatar and banner images so they will only be cached for 1 hour.

## Related Issue
#130 

## Type of Change
<!-- Choose one or more types that describe the changes in this PR -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please specify)

## Checklist
<!-- Check all that apply -->
- [x] I have tested the changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated relevant comments or documentation
- [x] All tests pass successfully
- [x] This PR follows the project's coding standards
