### PR TITLE
Set allow credentials to true in FastAPI middleware

### DIFF
--- a/src/auth_server.py
+++ b/src/auth_server.py
@@ -111,6 +111,7 @@ app = FastAPI(
 # Enable CORS
 app.add_middleware(
     CORSMiddleware,
+    allow_credentials=True,
     allow_origins=configurations['allow-origins'],
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Description
Set the `allow_credentials` option in the FastAPI middleware to `True`.

## Related Issue
#142 

## Type of Change
<!-- Choose one or more types that describe the changes in this PR -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please specify)

## Checklist
<!-- Check all that apply -->
- [x] I have tested the changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated relevant comments or documentation
- [x] All tests pass successfully
- [x] This PR follows the project's coding standards
