### PR TITLE
Improve 2fa setup

### DIFF
--- a/app/database/exceptions.py
+++ b/app/database/exceptions.py
@@ -12,3 +12,6 @@ class UserNotFound(Exception):
 
 class Conflict(Exception):
     pass
+
+class TwoFaNotSetup(Exception):
+    pass

--- a/app/database/update.py
+++ b/app/database/update.py
@@ -274,3 +274,44 @@ def save_2fa_secret(account_id: str, secret: str) -> None:
                    (secret, account_id))
     conn.commit()
     conn.close()
+
+def enable_2fa(user_id: str) -> None:
+    """
+    Enable 2-Factor Authentication on an account.
+    Parameters:
+        user_id (str): Id of the account.
+    """
+    conn = connections.get_connection()
+    cursor = conn.cursor()
+
+    # Check if the user has setup 2fa before enabling it
+    cursor.execute("SELECT 2fa_secret FROM accounts WHERE user_id = %s;",
+                   (user_id,))
+    account = cursor.fetchone()
+
+    if not account:
+        conn.close()
+        raise db_exceptions.UserNotFound()
+
+    if not isinstance(account[0], str):
+        conn.close()
+        raise db_exceptions.TwoFaNotSetup()
+    
+    cursor.execute("UPDATE accounts SET 2fa_enabled = 1 WHERE user_id = %s;",
+                   (user_id,))
+    conn.commit()
+    conn.close()
+
+def disable_2fa(user_id: str) -> None:
+    """
+    Disable 2-Factor Authentication on an account.
+    Parameters:
+        user_id (str): Id of the account.
+    """
+    conn = connections.get_connection()
+    cursor = conn.cursor()
+    
+    cursor.execute("UPDATE accounts SET 2fa_enabled = 0, 2fa_secret = NULL WHERE user_id = %s;",
+                   (user_id,))
+    conn.commit()
+    conn.close()

--- a/app/models/account.py
+++ b/app/models/account.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class TwoFaStatus(BaseModel):
+    status: Literal["DISABLED", "WAITING_APPROVAL", "ENABLED"]

--- a/app/models/common.py
+++ b/app/models/common.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+class StatusOk(BaseModel):
+    status: str = Field(default="Ok", frozen=True)
+    
+    class Config:
+        frozen = True

--- a/app/models/common.py
+++ b/app/models/common.py
@@ -1,4 +1,3 @@
-from pydantic import BaseModel
 from pydantic import BaseModel, Field
 
 class StatusOk(BaseModel):


### PR DESCRIPTION
## Description
Improved the 2FA enrollment process by doing the following:
1. Adding a "2fa_enabled" column to the database
2. Requiring one successful 2FA validation before enabling it
3. Only requiring a 2FA code if it has been enabled (before it was just based on whether there was a secret on the account)

## Related Issue
#164 

## Type of Change
<!-- Choose one or more types that describe the changes in this PR -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other: Improvement on existing feature

## Checklist
<!-- Check all that apply -->
- [x] I have tested the changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated relevant comments or documentation
- [x] All tests pass successfully
- [x] This PR follows the project's coding standards